### PR TITLE
Add comment notification updates

### DIFF
--- a/src/client/SocialNetworkClient.java
+++ b/src/client/SocialNetworkClient.java
@@ -487,6 +487,8 @@ public class SocialNetworkClient {
                                 String file = messageContent.substring(idx + " requests access to ".length()).trim();
                                 photoRequestSenders.add(sender);
                                 photoRequestFiles.add(file);
+                            } else if (messageContent.contains("commented on")) {
+                                updateLocalOthersWithNotification(notifications[i]);
                             } else if (messageContent.contains("approved your comment:")) {
                                 int idx = messageContent.indexOf(" approved your comment:");
                                 String approver = messageContent.substring(0, idx);
@@ -1391,9 +1393,31 @@ public class SocialNetworkClient {
         try {
             Path profilePath = Paths.get(LOCAL_DATA_DIR, clientID, "Profile_42" + clientID);
             Files.write(profilePath, (formatted + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);
+
+            // Also record the comment in our local Others file so followers' activities
+            // are kept consistent across clients
+            updateLocalOthersWithNotification(formatted);
+
             System.out.println("Local profile updated with comment.");
         } catch (IOException e) {
             System.err.println("Error updating local profile: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Appends a notification about another user's activity to our local Others file
+     * so it is reflected in the client's localdata.
+     * @param notificationEntry The notification text to store
+     */
+    private void updateLocalOthersWithNotification(String notificationEntry) {
+        try {
+            Path othersPath = Paths.get(LOCAL_DATA_DIR, clientID, "Others_42" + clientID + ".txt");
+            if (!Files.exists(othersPath)) {
+                Files.createFile(othersPath);
+            }
+            Files.write(othersPath, (notificationEntry + System.lineSeparator()).getBytes(), StandardOpenOption.APPEND);
+        } catch (IOException e) {
+            System.err.println("Error updating local others file: " + e.getMessage());
         }
     }
 

--- a/src/server/ClientHandler.java
+++ b/src/server/ClientHandler.java
@@ -1674,7 +1674,7 @@ private String readDescriptionForLanguage(Path enPath, Path grPath, String lang)
                         clientID,
                         followerID,
                         "post",
-                        clientID + " posted: " + formatted
+                        clientID + " commented on " + targetID + "'s post: " + comment
                 );
                 server.addNotification(notification);
 


### PR DESCRIPTION
## Summary
- ensure comment notifications mention when a user comments on another user's post
- store comment notifications in followers' local files
- record successful comment posts to both profile and local others file

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_684800be7a2483288fb3865d48bc658d