### PR TITLE
Improve photo search and access workflow

### DIFF
--- a/src/model/Notification.java
+++ b/src/model/Notification.java
@@ -30,8 +30,8 @@ public class Notification {
         this.timestamp = LocalDateTime.now();
         this.isRead = false;
 
-        // If it's a follow request, set status to pending
-        if (type.equals("follow_request")) {
+        // If it's a follow or photo request, set status to pending
+        if (type.equals("follow_request") || type.equals("photo_request")) {
             this.status = "pending";
         } else {
             this.status = "none";


### PR DESCRIPTION
## Summary
- track pending photo access requests on the client
- add ability to fetch photo descriptions and comments from the server
- allow requesting download after previewing details
- support pending photo request status in notifications
- handle granting/denying photo requests on the server

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_68483a5dadfc83288861e88bcaaa6c89